### PR TITLE
Fix otp release

### DIFF
--- a/apps/cvmfs_auth/src/cvmfs_auth_app.erl
+++ b/apps/cvmfs_auth/src/cvmfs_auth_app.erl
@@ -17,7 +17,6 @@
 %%====================================================================
 
 start(_StartType, _StartArgs) ->
-    {ok, MnesiaSchema} = application:get_env(cvmfs_services, mnesia_schema),
     case application:get_env(cvmfs_auth, repo_config) of
         {ok, {file, RepoConfigFile}} ->
             {ok, VarList} = file:consult(RepoConfigFile),
@@ -27,8 +26,7 @@ start(_StartType, _StartArgs) ->
     end,
 
     cvmfs_auth_sup:start_link({maps:get(repos, Vars)
-                              ,maps:get(acl, Vars)
-                              ,MnesiaSchema}).
+                              ,maps:get(acl, Vars)}).
 
 %%--------------------------------------------------------------------
 stop(_State) ->

--- a/apps/cvmfs_auth/test/cvmfs_auth_SUITE.erl
+++ b/apps/cvmfs_auth/test/cvmfs_auth_SUITE.erl
@@ -42,9 +42,9 @@ groups() ->
 %% Set up, tear down
 
 init_per_suite(Config) ->
+    application:load(mnesia),
+    application:set_env(mnesia, schema_location, ram),
     application:start(mnesia),
-
-    application:set_env(cvmfs_services, mnesia_schema, ram_copies),
 
     ok = application:load(cvmfs_auth),
     ok = ct:require(repos),
@@ -58,6 +58,7 @@ end_per_suite(_Config) ->
     application:stop(cvmfs_auth),
     application:unload(cvmfs_auth),
     application:stop(mnesia),
+    application:unload(mnesia),
     ok.
 
 init_per_testcase(_TestCase, _Config) ->

--- a/apps/cvmfs_lease/src/cvmfs_lease_app.erl
+++ b/apps/cvmfs_lease/src/cvmfs_lease_app.erl
@@ -18,8 +18,7 @@
 %%====================================================================
 
 start(_StartType, _StartArgs) ->
-    {ok, MnesiaSchema} = application:get_env(cvmfs_services, mnesia_schema),
-    cvmfs_lease_sup:start_link(MnesiaSchema).
+    cvmfs_lease_sup:start_link([]).
 
 %%--------------------------------------------------------------------
 stop(_State) ->

--- a/apps/cvmfs_lease/test/cvmfs_lease_SUITE.erl
+++ b/apps/cvmfs_lease/test/cvmfs_lease_SUITE.erl
@@ -37,13 +37,13 @@ groups() ->
 %% Set up, tear down
 
 init_per_suite(Config) ->
+    application:load(mnesia),
+    application:set_env(mnesia, schema_location, ram),
     application:start(mnesia),
-
-    application:set_env(cvmfs_services, mnesia_schema, ram_copies),
 
     MaxLeaseTime = 50, % milliseconds
     ok = application:load(cvmfs_lease),
-    ok = application:set_env(cvmfs_services, max_lease_time, MaxLeaseTime),
+    ok = application:set_env(cvmfs_lease, max_lease_time, MaxLeaseTime),
     {ok, _} = application:ensure_all_started(cvmfs_lease),
     lists:flatten([{max_lease_time, MaxLeaseTime}, Config]).
 
@@ -51,6 +51,7 @@ end_per_suite(_Config) ->
     application:stop(cvmfs_lease),
     application:unload(cvmfs_lease),
     application:stop(mnesia),
+    application:unload(mnesia),
     ok.
 
 init_per_testcase(_TestCase, Config) ->

--- a/apps/cvmfs_proc/src/cvmfs_proc.erl
+++ b/apps/cvmfs_proc/src/cvmfs_proc.erl
@@ -284,7 +284,7 @@ priv_generate_token(User, Path) ->
     M = macaroon:create(Location, Secret, Public),
     M1 = macaroon:add_first_party_caveat(M, "user = " ++ User),
 
-    {ok, MaxSessionTime} = application:get_env(cvmfs_services, max_session_time),
+    {ok, MaxSessionTime} = application:get_env(cvmfs_proc, max_session_time),
     Time = erlang:system_time(seconds) + MaxSessionTime,
 
     M2 = macaroon:add_first_party_caveat(M1, "time < " ++ erlang:integer_to_binary(Time)),

--- a/apps/cvmfs_proc/test/cvmfs_proc_SUITE.erl
+++ b/apps/cvmfs_proc/test/cvmfs_proc_SUITE.erl
@@ -50,9 +50,9 @@ groups() ->
 
 %% Set up and tear down
 init_per_suite(Config) ->
+    application:load(mnesia),
+    application:set_env(mnesia, schema_location, ram),
     application:start(mnesia),
-
-    application:set_env(cvmfs_services, mnesia_schema, ram_copies),
 
     ok = application:load(cvmfs_auth),
     ok = ct:require(repos),
@@ -63,12 +63,12 @@ init_per_suite(Config) ->
 
     MaxLeaseTime = 50, % milliseconds
     ok = application:load(cvmfs_lease),
-    ok = application:set_env(cvmfs_services, max_lease_time, MaxLeaseTime),
+    ok = application:set_env(cvmfs_lease, max_lease_time, MaxLeaseTime),
     {ok, _} = application:ensure_all_started(cvmfs_lease),
 
     MaxSessionTime = 1, % seconds
     ok = application:load(cvmfs_proc),
-    ok = application:set_env(cvmfs_services, max_session_time, MaxSessionTime),
+    ok = application:set_env(cvmfs_proc, max_session_time, MaxSessionTime),
     {ok, _} = application:ensure_all_started(cvmfs_proc),
 
     lists:flatten([[{max_lease_time, MaxLeaseTime}
@@ -83,6 +83,7 @@ end_per_suite(_Config) ->
     application:stop(cvmfs_auth),
     application:unload(cvmfs_auth),
     application:stop(mnesia),
+    application:unload(mnesia),
     ok.
 
 init_per_testcase(_TestCase, _Config) ->

--- a/config/sys.config.dev
+++ b/config/sys.config.dev
@@ -4,10 +4,13 @@
                      ,{lager_file_backend, [{file, "error.log"}, {level, error}]}
                      ,{lager_file_backend, [{file, "info.log"}, {level, info}]}]}]}
 
+,{mnesia, [{schema_location, disc}]}
+
 ,{cvmfs_auth, [{repo_config, {file, "./config/repo.config"}}]}
 
-,{cvmfs_proc, [{max_session_time, 3600000}]}
+,{cvmfs_lease, [{max_lease_time, 10000}]} % max lease time in milliseconds
 
-,{cvmfs_services, [{mnesia_schema, disc_copies} % disc_copies | ram_copies
-                  ,{max_session_time, 60}       % max session time in seconds
-                  ,{max_lease_time, 10000}]}].  % max lease time in milliseconds
+,{cvmfs_proc, [{max_session_time, 60}]} % max session time in seconds
+
+].
+

--- a/config/sys.config.rel
+++ b/config/sys.config.rel
@@ -4,10 +4,14 @@
                      ,{lager_file_backend, [{file, "error.log"}, {level, error}]}
                      ,{lager_file_backend, [{file, "info.log"}, {level, info}]}]}]}
 
+,{mnesia, [{dir, "/tmp/cvmfs_mnesia"}
+          ,{schema_location, disc}]}
+
 ,{cvmfs_auth, [{repo_config, {file, "./etc/repo.config"}}]}
 
-,{cvmfs_proc, [{max_session_time, 3600000}]}
+,{cvmfs_lease, [{max_lease_time, 10000}]} % max lease time in milliseconds
 
-,{cvmfs_services, [{mnesia_schema, disc_copies} % disc_copies | ram_copies
-                  ,{max_session_time, 60}       % max session time in seconds
-                  ,{max_lease_time, 10000}]}].  % max lease time in milliseconds
+,{cvmfs_proc, [{max_session_time, 60}]} % max session time in seconds
+
+].
+


### PR DESCRIPTION
This introduces some fixes for building the CVMFS services as an OTP release:

* Better configuration of Mnesia - using the `schema_location` variable it's possible to switch between disk based (for development and release) and ram based tables (for the test suite)
* During development (i.e. when the system is run with `rebar3 shell` or `rebar3 auto`, the location of the Mnesia schema is the current directory, which corresponds to the project root. When the release is built, the schema directory is `/tmp/cvmfs_mnesia`, which can be changed in the `config/sys.config.rel` file.