### PR TITLE
REST API - Initial implementation

### DIFF
--- a/apps/cvmfs_services/src/cvmfs_fe.erl
+++ b/apps/cvmfs_services/src/cvmfs_fe.erl
@@ -1,7 +1,7 @@
 %%%-------------------------------------------------------------------
 %%% This file is part of the CernVM File System.
 %%%
-%%% @doc cvmfs_fe public API
+%%% @doc cvmfs_fe - CVMFS repo services HTTP front-end
 %%%
 %%% @end
 %%%-------------------------------------------------------------------
@@ -10,7 +10,16 @@
 
 -export([start_link/0]).
 
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the front-end HTTP listener process.
+%%
+%% @end
+%%--------------------------------------------------------------------
 start_link() ->
+    %% Compile a routing table, for dispatching requests for different resources
+    %% to a set of handler modules. The handler modules implement the init/2 callback
+    %% required by Cowboy
     Dispatch = cowboy_router:compile([{'_', [
                                              {"/api", cvmfs_root_handler, []},
                                              {"/api/users/[:id]", cvmfs_users_handler, []},
@@ -18,6 +27,9 @@ start_link() ->
                                              {"/api/leases/[:id]", cvmfs_leases_handler, []},
                                              {"/api/payloads/[:id]", cvmfs_payloads_handler, []}
                                             ]}]),
+    %% Start the HTTP listener process configured with the routing table
+    %% TODO: Port and other parameters should not be hard-coded and should moved to
+    %%       the release configuration file
     cowboy:start_clear(cvmfs_fe, 100,
                        [{port, 8080}],
                        #{env => #{dispatch => Dispatch}}).

--- a/apps/cvmfs_services/src/cvmfs_fe.erl
+++ b/apps/cvmfs_services/src/cvmfs_fe.erl
@@ -15,7 +15,8 @@ start_link() ->
                                              {"/api", cvmfs_root_handler, []},
                                              {"/api/users/[:id]", cvmfs_users_handler, []},
                                              {"/api/repos/[:id]", cvmfs_repos_handler, []},
-                                             {"/api/leases/[:id]", cvmfs_leases_handler, []}
+                                             {"/api/leases/[:id]", cvmfs_leases_handler, []},
+                                             {"/api/payloads/[:id]", cvmfs_payloads_handler, []}
                                             ]}]),
     cowboy:start_clear(cvmfs_fe, 100,
                        [{port, 8080}],

--- a/apps/cvmfs_services/src/cvmfs_fe_util.erl
+++ b/apps/cvmfs_services/src/cvmfs_fe_util.erl
@@ -1,0 +1,25 @@
+%%%-------------------------------------------------------------------
+%%% This file is part of the CernVM File System.
+%%%
+%%% @doc cvmfs_lease_handler
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(cvmfs_fe_util).
+
+-export([read_body/1]).
+
+read_body(Req0) ->
+    read_body_rec(Req0, <<"">>).
+
+read_body_rec(Req0, Acc) ->
+    case cowboy_req:read_body(Req0) of
+        {ok, Data, Req1} ->
+            DataSize = size(Data),
+            {ok, <<Data:DataSize/binary,Acc/binary>>, Req1};
+        {more, Data, Req1} ->
+            DataSize = size(Data),
+            read_body_rec(Req1, <<Data:DataSize/binary,Acc/binary>>)
+    end.
+

--- a/apps/cvmfs_services/src/cvmfs_fe_util.erl
+++ b/apps/cvmfs_services/src/cvmfs_fe_util.erl
@@ -8,7 +8,9 @@
 
 -module(cvmfs_fe_util).
 
--export([read_body/1]).
+-compile([{parse_transform, lager_transform}]).
+
+-export([read_body/1, tick/2, tock/3]).
 
 read_body(Req0) ->
     read_body_rec(Req0, <<"">>).
@@ -23,3 +25,11 @@ read_body_rec(Req0, Acc) ->
             read_body_rec(Req1, <<Data:DataSize/binary,Acc/binary>>)
     end.
 
+tick(Req, Unit) ->
+    T = erlang:monotonic_time(Unit),
+    URI = cowboy_req:uri(Req),
+    {URI, T}.
+
+tock(URI, T0, Unit) ->
+    T1 = erlang:monotonic_time(Unit),
+    lager:info("HTTP request received: ~p ; time to process = ~p usec", [URI, T1 - T0]).

--- a/apps/cvmfs_services/src/cvmfs_leases_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_leases_handler.erl
@@ -16,7 +16,7 @@ init(Req0 = #{method := <<"GET">>}, State) ->
                            <<"">>,
                            Req0),
     {ok, Req1, State};
-init(Req0 = #{method := <<"PUT">>}, State) ->
+init(Req0 = #{method := <<"POST">>}, State) ->
     {Status, Reply, Req2} = case p_read_body(Req0) of
                                 {ok, Data, Req1} ->
                                     case jsx:decode(Data, [return_maps]) of

--- a/apps/cvmfs_services/src/cvmfs_leases_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_leases_handler.erl
@@ -12,8 +12,8 @@
 
 init(Req0 = #{method := <<"GET">>}, State) ->
     Req1 = cowboy_req:reply(405,
-                           #{<<"content-type">> => <<"application/json">>},
-                           jsx:encode(#{}),
+                           #{<<"content-type">> => <<"application/plain-text">>},
+                           <<"">>,
                            Req0),
     {ok, Req1, State};
 init(Req0 = #{method := <<"PUT">>}, State) ->

--- a/apps/cvmfs_services/src/cvmfs_leases_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_leases_handler.erl
@@ -17,7 +17,7 @@ init(Req0 = #{method := <<"GET">>}, State) ->
                            Req0),
     {ok, Req1, State};
 init(Req0 = #{method := <<"POST">>}, State) ->
-    {Status, Reply, Req2} = case p_read_body(Req0) of
+    {Status, Reply, Req2} = case cvmfs_fe_util:read_body(Req0) of
                                 {ok, Data, Req1} ->
                                     case jsx:decode(Data, [return_maps]) of
                                         #{<<"user">> := User, <<"path">> := Path} ->
@@ -59,15 +59,6 @@ init(Req0 = #{method := <<"DELETE">>}, State) ->
             {ok, Req1, State}
     end.
 
-
-%%% Private functions
-p_read_body(Req) ->
-    case cowboy_req:has_body(Req) of
-        true ->
-            cowboy_req:read_body(Req);
-        false ->
-            {}
-    end.
 
 p_new_lease(User, Path) ->
     case cvmfs_be:new_lease(User, Path) of

--- a/apps/cvmfs_services/src/cvmfs_leases_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_leases_handler.erl
@@ -17,17 +17,13 @@ init(Req0 = #{method := <<"GET">>}, State) ->
                            Req0),
     {ok, Req1, State};
 init(Req0 = #{method := <<"POST">>}, State) ->
-    {Status, Reply, Req2} = case cvmfs_fe_util:read_body(Req0) of
-                                {ok, Data, Req1} ->
-                                    case jsx:decode(Data, [return_maps]) of
-                                        #{<<"user">> := User, <<"path">> := Path} ->
-                                            Rep = p_new_lease(User, Path),
-                                            {200, Rep, Req1};
-                                        _ ->
-                                            {400, #{}, Req1}
-                                    end;
+    {ok, Data, Req1} = cvmfs_fe_util:read_body(Req0),
+    {Status, Reply, Req2} = case jsx:decode(Data, [return_maps]) of
+                                #{<<"user">> := User, <<"path">> := Path} ->
+                                    Rep = p_new_lease(User, Path),
+                                    {200, Rep, Req1};
                                 _ ->
-                                    {400, #{}, Req0}
+                                    {400, #{}, Req1}
                             end,
     ReqF = cowboy_req:reply(Status,
                             #{<<"content-type">> => <<"application/json">>},

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -1,0 +1,22 @@
+%%%-------------------------------------------------------------------
+%%% This file is part of the CernVM File System.
+%%%
+%%% @doc cvmfs_payloads_handler
+%%%
+%%% @end
+%%%-------------------------------------------------------------------
+
+-module(cvmfs_payloads_handler).
+
+-export([init/2]).
+
+init(Req0 = #{method := <<"GET">>}, State) ->
+    Req1 = cowboy_req:reply(405,
+                           #{<<"content-type">> => <<"application/plain-text">>},
+                           <<"">>,
+                           Req0),
+    {ok, Req1, State};
+init(Req0 = #{method := <<"PUT">>}, State) ->
+    {ok, Req0, State}.
+
+

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -16,7 +16,7 @@ init(Req0 = #{method := <<"GET">>}, State) ->
                            <<"">>,
                            Req0),
     {ok, Req1, State};
-init(Req0 = #{method := <<"PUT">>}, State) ->
+init(Req0 = #{method := <<"POST">>}, State) ->
     {ok, Req0, State}.
 
 

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -17,23 +17,19 @@ init(Req0 = #{method := <<"GET">>}, State) ->
                            Req0),
     {ok, Req1, State};
 init(Req0 = #{method := <<"POST">>}, State) ->
-    {Status, Reply, Req2} = case cvmfs_fe_util:read_body(Req0) of
-                                {ok, Data, Req1} ->
-                                    case jsx:decode(Data, [return_maps]) of
-                                        #{<<"user">> := User,
-                                          <<"session_token">> := Token,
-                                          <<"payload">> := Payload,
-                                          <<"final">> := Final} ->
-                                            Rep = p_submit_payload(User,
-                                                                   Token,
-                                                                   Payload,
-                                                                   binary_to_atom(Final, latin1)),
-                                            {200, Rep, Req1};
-                                        _ ->
-                                            {400, #{}, Req1}
-                                    end;
+    {ok, Data, Req1} = cvmfs_fe_util:read_body(Req0),
+    {Status, Reply, Req2} = case jsx:decode(Data, [return_maps]) of
+                                #{<<"user">> := User,
+                                  <<"session_token">> := Token,
+                                  <<"payload">> := Payload,
+                                  <<"final">> := Final} ->
+                                    Rep = p_submit_payload(User,
+                                                           Token,
+                                                           Payload,
+                                                           binary_to_atom(Final, latin1)),
+                                    {200, Rep, Req1};
                                 _ ->
-                                    {400, #{}, Req0}
+                                    {400, #{}, Req1}
                             end,
     ReqF = cowboy_req:reply(Status,
                             #{<<"content-type">> => <<"application/json">>},

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -23,10 +23,14 @@
 %% @end
 %%--------------------------------------------------------------------
 init(Req0 = #{method := <<"GET">>}, State) ->
+    {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+
     Req1 = cowboy_req:reply(405,
                            #{<<"content-type">> => <<"application/plain-text">>},
                            <<"">>,
                            Req0),
+
+    cvmfs_fe_util:tock(URI, T0, micro_seconds),
     {ok, Req1, State};
 %% @doc
 %% A "POST" request to /api/payloads, which can return either 200 OK
@@ -41,6 +45,8 @@ init(Req0 = #{method := <<"GET">>}, State) ->
 %% @end
 %%--------------------------------------------------------------------
 init(Req0 = #{method := <<"POST">>}, State) ->
+    {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+
     {ok, Data, Req1} = cvmfs_fe_util:read_body(Req0),
     {Status, Reply, Req2} = case jsx:decode(Data, [return_maps]) of
                                 #{<<"user">> := User,
@@ -57,6 +63,8 @@ init(Req0 = #{method := <<"POST">>}, State) ->
                             #{<<"content-type">> => <<"application/json">>},
                             jsx:encode(Reply),
                             Req2),
+
+    cvmfs_fe_util:tock(URI, T0, micro_seconds),
     {ok, ReqF, State}.
 
 

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -17,6 +17,37 @@ init(Req0 = #{method := <<"GET">>}, State) ->
                            Req0),
     {ok, Req1, State};
 init(Req0 = #{method := <<"POST">>}, State) ->
-    {ok, Req0, State}.
+    {Status, Reply, Req2} = case cvmfs_fe_util:read_body(Req0) of
+                                {ok, Data, Req1} ->
+                                    case jsx:decode(Data, [return_maps]) of
+                                        #{<<"user">> := User,
+                                          <<"session_token">> := Token,
+                                          <<"payload">> := Payload,
+                                          <<"final">> := Final} ->
+                                            Rep = p_submit_payload(User,
+                                                                   Token,
+                                                                   Payload,
+                                                                   binary_to_atom(Final, latin1)),
+                                            {200, Rep, Req1};
+                                        _ ->
+                                            {400, #{}, Req1}
+                                    end;
+                                _ ->
+                                    {400, #{}, Req0}
+                            end,
+    ReqF = cowboy_req:reply(Status,
+                            #{<<"content-type">> => <<"application/json">>},
+                            jsx:encode(Reply),
+                            Req2),
+    {ok, ReqF, State}.
 
+p_submit_payload(User, Token, Payload, Final) ->
+    case cvmfs_be:submit_payload(User, Token, Payload, Final) of
+        {ok, payload_added} ->
+            #{<<"status">> => <<"ok">>};
+        {ok, payload_added, lease_ended} ->
+            #{<<"status">> => <<"ok">>};
+        {error, Reason} ->
+            #{<<"status">> => <<"error">>, <<"reason">> => atom_to_binary(Reason, latin1)}
+    end.
 

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -33,7 +33,7 @@ init(Req0 = #{method := <<"GET">>}, State) ->
 %% or in 400 - Bad Request
 %%
 %% The body of the request should be a JSON payload containing the
-%% "user", "session_token", "payload" and "final" fields
+%% "user", "session_token" and "payload" fields
 %%
 %% The body of the reply, for a valid request contains the fields:
 %% "status" - either "ok", "error"
@@ -45,12 +45,10 @@ init(Req0 = #{method := <<"POST">>}, State) ->
     {Status, Reply, Req2} = case jsx:decode(Data, [return_maps]) of
                                 #{<<"user">> := User,
                                   <<"session_token">> := Token,
-                                  <<"payload">> := Payload,
-                                  <<"final">> := Final} ->
+                                  <<"payload">> := Payload} ->
                                     Rep = p_submit_payload(User,
                                                            Token,
-                                                           Payload,
-                                                           binary_to_atom(Final, latin1)),
+                                                           Payload),
                                     {200, Rep, Req1};
                                 _ ->
                                     {400, #{}, Req1}
@@ -65,11 +63,9 @@ init(Req0 = #{method := <<"POST">>}, State) ->
 %% Private functions
 
 
-p_submit_payload(User, Token, Payload, Final) ->
-    case cvmfs_be:submit_payload(User, Token, Payload, Final) of
+p_submit_payload(User, Token, Payload) ->
+    case cvmfs_be:submit_payload(User, Token, Payload) of
         {ok, payload_added} ->
-            #{<<"status">> => <<"ok">>};
-        {ok, payload_added, lease_ended} ->
             #{<<"status">> => <<"ok">>};
         {error, Reason} ->
             #{<<"status">> => <<"error">>, <<"reason">> => atom_to_binary(Reason, latin1)}

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -1,7 +1,8 @@
 %%%-------------------------------------------------------------------
 %%% This file is part of the CernVM File System.
 %%%
-%%% @doc cvmfs_payloads_handler
+%%% @doc cvmfs_payloads_handler - request handler for the "payloads"
+%%%                               resource
 %%%
 %%% @end
 %%%-------------------------------------------------------------------
@@ -10,12 +11,35 @@
 
 -export([init/2]).
 
+%%--------------------------------------------------------------------
+%% @doc
+%% Handles requests for the /api/payloads resource
+%%
+%% @end
+%%--------------------------------------------------------------------
+%%--------------------------------------------------------------------
+%% @doc
+%% A "GET" request to /api/payloads returns 405 - method not allowed
+%% @end
+%%--------------------------------------------------------------------
 init(Req0 = #{method := <<"GET">>}, State) ->
     Req1 = cowboy_req:reply(405,
                            #{<<"content-type">> => <<"application/plain-text">>},
                            <<"">>,
                            Req0),
     {ok, Req1, State};
+%% @doc
+%% A "POST" request to /api/payloads, which can return either 200 OK
+%% or in 400 - Bad Request
+%%
+%% The body of the request should be a JSON payload containing the
+%% "user", "session_token", "payload" and "final" fields
+%%
+%% The body of the reply, for a valid request contains the fields:
+%% "status" - either "ok", "error"
+%% "reason" - if status is "error", this is a description of the error.
+%% @end
+%%--------------------------------------------------------------------
 init(Req0 = #{method := <<"POST">>}, State) ->
     {ok, Data, Req1} = cvmfs_fe_util:read_body(Req0),
     {Status, Reply, Req2} = case jsx:decode(Data, [return_maps]) of
@@ -36,6 +60,10 @@ init(Req0 = #{method := <<"POST">>}, State) ->
                             jsx:encode(Reply),
                             Req2),
     {ok, ReqF, State}.
+
+
+%% Private functions
+
 
 p_submit_payload(User, Token, Payload, Final) ->
     case cvmfs_be:submit_payload(User, Token, Payload, Final) of

--- a/apps/cvmfs_services/src/cvmfs_repos_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_repos_handler.erl
@@ -1,7 +1,7 @@
 %%%-------------------------------------------------------------------
 %%% This file is part of the CernVM File System.
 %%%
-%%% @doc cvmfs_repo_handler
+%%% @doc cvmfs_repos_handler - request handler for the "repos" resource
 %%%
 %%% @end
 %%%-------------------------------------------------------------------
@@ -10,6 +10,13 @@
 
 -export([init/2]).
 
+%%--------------------------------------------------------------------
+%% @doc
+%% Handles requests for the /api/resource resource, returning a list
+%% of registered repositories
+%%
+%% @end
+%%--------------------------------------------------------------------
 init(Req0, State) ->
     Repos = cvmfs_auth:get_repos(),
     Req = cowboy_req:reply(200,

--- a/apps/cvmfs_services/src/cvmfs_repos_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_repos_handler.erl
@@ -18,10 +18,14 @@
 %% @end
 %%--------------------------------------------------------------------
 init(Req0, State) ->
+    {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+
     Repos = cvmfs_auth:get_repos(),
     Req = cowboy_req:reply(200,
                            #{<<"content-type">> => <<"application/json">>},
                            jsx:encode(#{<<"repos">> => Repos}),
                            Req0),
+
+    cvmfs_fe_util:tock(URI, T0, micro_seconds),
     {ok, Req, State}.
 

--- a/apps/cvmfs_services/src/cvmfs_root_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_root_handler.erl
@@ -1,7 +1,7 @@
 %%%-------------------------------------------------------------------
 %%% This file is part of the CernVM File System.
 %%%
-%%% @doc cvmfs__root_handler
+%%% @doc cvmfs_root_handler - request handler for the API root
 %%%
 %%% @end
 %%%-------------------------------------------------------------------
@@ -10,6 +10,14 @@
 
 -export([init/2]).
 
+%%--------------------------------------------------------------------
+%% @doc
+%% Handles requests for the /api resource
+%%
+%% Return a list of available resources.
+%%
+%% @end
+%%--------------------------------------------------------------------
 init(Req0, State) ->
     Banner = <<"You are in an open field on the west side of a white house with a boarded front door.">>,
     API = #{<<"banner">> => Banner,

--- a/apps/cvmfs_services/src/cvmfs_root_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_root_handler.erl
@@ -19,6 +19,8 @@
 %% @end
 %%--------------------------------------------------------------------
 init(Req0, State) ->
+    {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+
     Banner = <<"You are in an open field on the west side of a white house with a boarded front door.">>,
     API = #{<<"banner">> => Banner,
             <<"resources">> => [<<"users">>, <<"repos">>, <<"leases">>, <<"payloads">>]},
@@ -26,5 +28,7 @@ init(Req0, State) ->
                            #{<<"content-type">> => <<"text/plain">>},
                            jsx:encode(API),
                            Req0),
+
+    cvmfs_fe_util:tock(URI, T0, micro_seconds),
     {ok, Req, State}.
 

--- a/apps/cvmfs_services/src/cvmfs_root_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_root_handler.erl
@@ -13,7 +13,7 @@
 init(Req0, State) ->
     Banner = <<"You are in an open field on the west side of a white house with a boarded front door.">>,
     API = #{<<"banner">> => Banner,
-            <<"resources">> => [<<"users">>, <<"repos">>, <<"leases">>]},
+            <<"resources">> => [<<"users">>, <<"repos">>, <<"leases">>, <<"payloads">>]},
     Req = cowboy_req:reply(200,
                            #{<<"content-type">> => <<"text/plain">>},
                            jsx:encode(API),

--- a/apps/cvmfs_services/src/cvmfs_services_app.erl
+++ b/apps/cvmfs_services/src/cvmfs_services_app.erl
@@ -23,7 +23,7 @@ start(_StartType, _StartArgs) ->
                    maps:from_list(VarList);
                {ok, RepoConfigMap} ->
                    RepoConfigMap;
-               _ ->
+               undefined ->
                    #{repos => [], acl => []}
            end,
     {ok, Services} = application:get_env(enabled_services),

--- a/apps/cvmfs_services/src/cvmfs_users_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_users_handler.erl
@@ -18,10 +18,14 @@
 %% @end
 %%--------------------------------------------------------------------
 init(Req0, State) ->
+    {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+
     Users = cvmfs_auth:get_users(),
     Req = cowboy_req:reply(200,
                            #{<<"content-type">> => <<"application/json">>},
                            jsx:encode(#{<<"users">> => Users}),
                            Req0),
+
+    cvmfs_fe_util:tock(URI, T0, micro_seconds),
     {ok, Req, State}.
 

--- a/apps/cvmfs_services/src/cvmfs_users_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_users_handler.erl
@@ -1,7 +1,7 @@
 %%%-------------------------------------------------------------------
 %%% This file is part of the CernVM File System.
 %%%
-%%% @doc cvmfs__user_handler
+%%% @doc cvmfs_users_handler - request handler for the "users" resource
 %%%
 %%% @end
 %%%-------------------------------------------------------------------
@@ -10,6 +10,13 @@
 
 -export([init/2]).
 
+%%--------------------------------------------------------------------
+%% @doc
+%% Handles requests for the /api/users resource, returning the list of
+%% registered users
+%%
+%% @end
+%%--------------------------------------------------------------------
 init(Req0, State) ->
     Users = cvmfs_auth:get_users(),
     Req = cowboy_req:reply(200,

--- a/apps/cvmfs_services/test/cvmfs_auth_SUITE.erl
+++ b/apps/cvmfs_services/test/cvmfs_auth_SUITE.erl
@@ -44,7 +44,7 @@ groups() ->
 init_per_suite(Config) ->
     application:load(mnesia),
     application:set_env(mnesia, schema_location, ram),
-    application:start(mnesia),
+    application:ensure_all_started(mnesia),
 
     ok = application:load(cvmfs_services),
     ok = ct:require(repos),

--- a/apps/cvmfs_services/test/cvmfs_be_SUITE.erl
+++ b/apps/cvmfs_services/test/cvmfs_be_SUITE.erl
@@ -148,19 +148,20 @@ lease_success(_Config) ->
     {User, Path} = valid_user_and_path(),
     Payload = <<"placeholder_for_a_real_payload">>,
     {ok, Token} = cvmfs_be:new_lease(User, Path),
-    % Followup with a payload submission (final = false)
-    {ok, payload_added} = cvmfs_be:submit_payload(User, Token, Payload, false),
-    % Submit final payload
-    {ok, payload_added, lease_ended} = cvmfs_be:submit_payload(User, Token, Payload, true),
+    % Followup with a payload submission
+    {ok, payload_added} = cvmfs_be:submit_payload(User, Token, Payload),
+    % Submit final payload and end the lease
+    {ok, payload_added} = cvmfs_be:submit_payload(User, Token, Payload),
+    ok = cvmfs_be:end_lease(Token),
     % After the lease has been closed, the token should be rejected
-    {error, invalid_lease} = cvmfs_be:submit_payload(User, Token, Payload, true).
+    {error, invalid_lease} = cvmfs_be:submit_payload(User, Token, Payload).
 
 % Attempt to submit a payload without first obtaining a token
 submission_with_invalid_token_fails(_Config) ->
     {User, _} = valid_user_and_path(),
     Token = <<"invalid_token">>,
     Payload = <<"placeholder">>,
-    {error, invalid_macaroon} = cvmfs_be:submit_payload(User, Token, Payload, false).
+    {error, invalid_macaroon} = cvmfs_be:submit_payload(User, Token, Payload).
 
 % Start a valid lease, make submission after the token has expired
 submission_with_expired_token_fails(Config) ->
@@ -168,14 +169,14 @@ submission_with_expired_token_fails(Config) ->
     Payload = <<"placeholder">>,
     {ok, Token} = cvmfs_be:new_lease(User, Path),
     ct:sleep(?config(max_lease_time, Config)),
-    {error, lease_expired} = cvmfs_be:submit_payload(User, Token, Payload, false).
+    {error, lease_expired} = cvmfs_be:submit_payload(User, Token, Payload).
 
 submission_with_different_user_name(_Config) ->
     {VUser, VPath} = valid_user_and_path(),
     {IUser, _} = invalid_user_and_path(VUser, VPath),
     Payload = <<"placeholder">>,
     {ok, Token} = cvmfs_be:new_lease(VUser, VPath),
-    {error, invalid_user} = cvmfs_be:submit_payload(IUser, Token, Payload, false).
+    {error, invalid_user} = cvmfs_be:submit_payload(IUser, Token, Payload).
 
 
 %% Properties

--- a/apps/cvmfs_services/test/cvmfs_be_SUITE.erl
+++ b/apps/cvmfs_services/test/cvmfs_be_SUITE.erl
@@ -62,7 +62,7 @@ groups() ->
 init_per_suite(Config) ->
     application:load(mnesia),
     application:set_env(mnesia, schema_location, ram),
-    application:start(mnesia),
+    application:ensure_all_started(mnesia),
 
     ok = application:load(cvmfs_services),
     ok = ct:require(repos),

--- a/apps/cvmfs_services/test/cvmfs_fe_SUITE.erl
+++ b/apps/cvmfs_services/test/cvmfs_fe_SUITE.erl
@@ -1,0 +1,180 @@
+%%%-------------------------------------------------------------------
+%%% This file is part of the CernVM File System.
+%%%
+%%% @doc
+%%%
+%%% @end
+%%%
+%%%-------------------------------------------------------------------
+
+-module(cvmfs_fe_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-export([all/0, groups/0, init_per_suite/1, end_per_suite/1,
+         init_per_testcase/2, end_per_testcase/2]).
+
+-export([check_root/1, check_users/1, check_repos/1, check_leases/1]).
+-export([create_and_delete_session/1,
+         create_invalid_sessions/1,
+         create_session_when_already_created/1,
+         end_invalid_session/1]).
+
+
+%% Test description
+
+all() ->
+    [{group, resource_check},
+     {group, sessions}].
+
+groups() ->
+    [
+     {resource_check, [], [check_root, check_users, check_repos, check_leases]},
+     {sessions, [], [create_and_delete_session,
+                     create_invalid_sessions,
+                     create_session_when_already_created,
+                     end_invalid_session]}
+    ].
+
+
+%% Set up and tear down
+
+init_per_suite(Config) ->
+    application:load(mnesia),
+    application:set_env(mnesia, schema_location, ram),
+    application:ensure_all_started(mnesia),
+
+    application:ensure_all_started(gun),
+
+    ok = application:load(cvmfs_services),
+    ok = ct:require(repos),
+    ok = ct:require(acl),
+    ok = application:set_env(cvmfs_services, enabled_services, [cvmfs_auth, cvmfs_lease, cvmfs_be, cvmfs_fe]),
+    ok = application:set_env(cvmfs_services, repo_config, #{repos => ct:get_config(repos)
+                                                           ,acl => ct:get_config(acl)}),
+    MaxLeaseTime = 50, % milliseconds
+    ok = application:set_env(cvmfs_services, max_lease_time, MaxLeaseTime),
+
+    {ok, _} = application:ensure_all_started(cvmfs_services),
+
+    [{max_lease_time, MaxLeaseTime} | Config].
+
+end_per_suite(_Config) ->
+    application:stop(cvmfs_services),
+    application:unload(cvmfs_services),
+    application:stop(gun),
+    application:stop(mnesia),
+    application:unload(mnesia),
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    {ok, ConnPid} = gun:open("localhost", 8080),
+    {ok, http} = gun:await_up(ConnPid),
+    [{gun_connection, ConnPid} | Config].
+
+end_per_testcase(_TestCase, Config) ->
+    ConnPid = ?config(gun_connection, Config),
+    ok = gun:shutdown(ConnPid),
+    ok.
+
+
+%% Test specifications
+
+check_root(Config) ->
+    {ok, Body} = p_get(conn_pid(Config), "/api"),
+    #{<<"resources">> := Resources} = jsx:decode(Body, [return_maps]),
+    Resources =:= [<<"users">>, <<"repos">>, <<"leases">>, <<"payloads">>].
+
+
+check_users(Config) ->
+    {ok, Body} = p_get(conn_pid(Config), "/api/users"),
+    #{<<"users">> := Users} = jsx:decode(Body, [return_maps]),
+    Users =:= cvmfs_auth:get_users().
+
+
+check_repos(Config) ->
+    {ok, Body} = p_get(conn_pid(Config), "/api/repos"),
+    #{<<"repos">> := Repos} = jsx:decode(Body, [return_maps]),
+    Repos =:= cvmfs_auth:get_repos().
+
+
+check_leases(Config) ->
+    {error, reply_without_body} = p_get(conn_pid(Config), "/api/leases").
+
+
+create_and_delete_session(Config) ->
+    RequestBody = jsx:encode(#{<<"user">> => <<"user1">>, <<"path">> => <<"/path/to/repo/1">>}),
+    RequestHeaders = [{<<"content-type">>, <<"application/json">>},
+                      {<<"content-length">>, integer_to_binary(size(RequestBody))}],
+    {ok, ReplyBody1} = p_post(conn_pid(Config), "/api/leases", RequestHeaders, RequestBody),
+    #{<<"session_token">> := Token} = jsx:decode(ReplyBody1, [return_maps]),
+    {ok, ReplyBody2} = p_delete(conn_pid(Config), "/api/leases/" ++ binary_to_list(Token)),
+    #{<<"status">> := <<"ok">>} = jsx:decode(ReplyBody2, [return_maps]).
+
+
+create_invalid_sessions(Config) ->
+    RequestReplies = [
+                      {<<"bad_user">>, <<"/path/to/repo/1">>, <<"invalid_user">>},
+                      {<<"user1">>, <<"bad_path">>, <<"invalid_path">>}
+                     ],
+    Check = fun({User, Path, Reason}) ->
+                     RequestBody = jsx:encode(#{<<"user">> => User, <<"path">> => Path}),
+                     RequestHeaders = [{<<"content-type">>, <<"application/json">>},
+                                       {<<"content-length">>, integer_to_binary(size(RequestBody))}],
+                     {ok, ReplyBody} = p_post(conn_pid(Config), "/api/leases", RequestHeaders, RequestBody),
+                     #{<<"status">> := <<"error">>,
+                       <<"reason">> := Reason} = jsx:decode(ReplyBody, [return_maps])
+             end,
+    lists:foreach(Check, RequestReplies).
+
+
+create_session_when_already_created(Config) ->
+    RequestBody = jsx:encode(#{<<"user">> => <<"user1">>, <<"path">> => <<"/path/to/repo/1">>}),
+    RequestHeaders = [{<<"content-type">>, <<"application/json">>},
+                      {<<"content-length">>, integer_to_binary(size(RequestBody))}],
+    {ok, ReplyBody1} = p_post(conn_pid(Config), "/api/leases", RequestHeaders, RequestBody),
+    #{<<"session_token">> := _Token} = jsx:decode(ReplyBody1, [return_maps]),
+    {ok, ReplyBody2} = p_post(conn_pid(Config), "/api/leases", RequestHeaders, RequestBody),
+    #{<<"status">> := <<"path_busy">>} = jsx:decode(ReplyBody2, [return_maps]).
+
+
+end_invalid_session(Config) ->
+    {ok, Body} = p_delete(conn_pid(Config), "/api/leases/NOT_A_PROPER_SESSION_TOKEN"),
+    #{<<"status">> := <<"error">>,
+      <<"reason">> := <<"invalid_token">>} = jsx:decode(Body, [return_maps]).
+
+
+%% Private functions
+
+conn_pid(Config) ->
+    ?config(gun_connection, Config).
+
+
+p_wait(ConnPid, StreamRef) ->
+    case gun:await(ConnPid, StreamRef, 1000) of
+        {response, nofin, _Status, _Headers} ->
+            gun:await_body(ConnPid, StreamRef);
+        {response, fin, _Status, _Headers} ->
+            {error, reply_without_body}
+    end.
+
+
+-spec p_get(Config, Path) -> {ok, Body} | {error, Reason}
+                                  when Config :: [{atom(), term()}],
+                                       Path :: string(),
+                                       Body :: binary(),
+                                       Reason :: term().
+p_get(ConnPid, Path) ->
+    p_wait(ConnPid, gun:get(ConnPid, Path)).
+
+
+p_post(ConnPid, Path, Headers, Body) ->
+    StreamRef = gun:post(ConnPid, Path, Headers),
+    gun:data(ConnPid, StreamRef, fin, Body),
+    p_wait(ConnPid, StreamRef).
+
+
+p_delete(ConnPid, Path) ->
+    p_wait(ConnPid, gun:delete(ConnPid, Path)).

--- a/apps/cvmfs_services/test/cvmfs_fe_SUITE.erl
+++ b/apps/cvmfs_services/test/cvmfs_fe_SUITE.erl
@@ -159,7 +159,7 @@ normal_payload_submission(Config) ->
     % Submit payload
     Payload = <<"IAMAPAYLOAD">>,
     RequestBody2 = jsx:encode(#{<<"user">> => <<"user1">>, <<"session_token">> => Token,
-                                <<"payload">> => Payload, <<"final">> => <<"false">>}),
+                                <<"payload">> => Payload}),
     RequestHeaders2 = p_make_headers(RequestBody2),
     {ok, ReplyBody2} = p_post(conn_pid(Config), "/api/payloads", RequestHeaders2, RequestBody2),
     #{<<"status">> := <<"ok">>} = jsx:decode(ReplyBody2, [return_maps]),

--- a/apps/cvmfs_services/test/cvmfs_lease_SUITE.erl
+++ b/apps/cvmfs_services/test/cvmfs_lease_SUITE.erl
@@ -45,7 +45,7 @@ groups() ->
 init_per_suite(Config) ->
     application:load(mnesia),
     application:set_env(mnesia, schema_location, ram),
-    application:start(mnesia),
+    application:ensure_all_started(mnesia),
 
     MaxLeaseTime = 50, % milliseconds
     ok = application:load(cvmfs_services),

--- a/rebar.config
+++ b/rebar.config
@@ -7,9 +7,16 @@
        ]}.
 
 {relx, [{release, {cvmfs_services, "0.1.0"}
-        ,[cvmfs_services
-         ,runtime_tools
-         ,sasl]}
+        ,[cvmfs_services,
+          mnesia,
+          lager,
+          cowboy,
+          jsx,
+          macaroons,
+          base64url,
+          enacl_p,
+          runtime_tools,
+          sasl]}
 
        ,{sys_config, "./config/sys.config.rel"}
        ,{vm_args, "./config/vm.args"}

--- a/rebar.config
+++ b/rebar.config
@@ -33,5 +33,6 @@
 
 {profiles, [{prod, [{relx, [{dev_mode, false}
                            ,{include_erts, true}]}]}
-           ,{test, [{deps, [{proper, "1.1.1-beta"}]}]}]}.
+           ,{test, [{deps, [{proper, "1.1.1-beta"},
+                            {gun, "1.0.0-pre.1"}]}]}]}.
 

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -18,7 +18,7 @@ def do_request(url, method, body):
         pass
 
 def create_and_delete_session():
-    rep1 = do_request('/api/leases', 'POST', {'userr' : 'user1', 'path' : '/path/to/repo/1'})
+    rep1 = do_request('/api/leases', 'POST', {'user' : 'user1', 'path' : '/path/to/repo/1'})
     print 'New session: ', rep1
     token = rep1['session_token']
     rep2 = do_request('/api/leases/' + token, 'DELETE', {})
@@ -37,9 +37,9 @@ def main():
 
     create_and_delete_session()
 
-    # for (u, m, b) in url_resp:
-    #     rep = do_request(u, m, b)
-    #     print rep
+    for (u, m, b) in url_resp:
+        rep = do_request(u, m, b)
+        print rep
 
 
 if __name__ == '__main__':

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -18,7 +18,7 @@ def do_request(url, method, body):
         pass
 
 def create_and_delete_session():
-    rep1 = do_request('/api/leases', 'PUT', {'user' : 'user1', 'path' : '/path/to/repo/1'})
+    rep1 = do_request('/api/leases', 'POST', {'userr' : 'user1', 'path' : '/path/to/repo/1'})
     print 'New session: ', rep1
     token = rep1['session_token']
     rep2 = do_request('/api/leases/' + token, 'DELETE', {})
@@ -30,16 +30,16 @@ def main():
                 (base_res + 'users', 'GET', {}),
                 (base_res + 'repos', 'GET', {}),
                 (base_res + 'leases', 'GET', {}),
-                (base_res + 'leases', 'PUT', {'user' : 'user1', 'path' : '/path/to/repo/1'}),
-                (base_res + 'leases', 'PUT', {'user' : 'bad_user', 'path' : '/path/to/repo/1'}),
-                (base_res + 'leases', 'PUT', {'user' : 'user1', 'path' : '/bad/path'}),
-                (base_res + 'leases', 'PUT', {'user' : 'user1', 'path' : '/path/to/repo/1'})]
+                (base_res + 'leases', 'POST', {'user' : 'user1', 'path' : '/path/to/repo/1'}),
+                (base_res + 'leases', 'POST', {'user' : 'bad_user', 'path' : '/path/to/repo/1'}),
+                (base_res + 'leases', 'POST', {'user' : 'user1', 'path' : '/bad/path'}),
+                (base_res + 'leases', 'POST', {'user' : 'user1', 'path' : '/path/to/repo/1'})]
 
     create_and_delete_session()
 
-    for (u, m, b) in url_resp:
-        rep = do_request(u, m, b)
-        print rep
+    # for (u, m, b) in url_resp:
+    #     rep = do_request(u, m, b)
+    #     print rep
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR contains an initial implementation of the HTTP/REST API front-end:

* The HTTP front-end is implemented in the `cvmfs_fe` modules
* The internal API defined in `cvmfs_be.erl`, based on Erlang terms, is wrapped by REST methods
* Using the `Cowboy` embedded HTTP server to handle HTTP requests
* Using the `Gun` HTTP client for testing the HTTP API
* Using `JSX` for JSON encoding/decoding

After the following items are done, this can be merged:
* [x] Cleanup
* [x] Documentation