### PR TITLE
API logging and tagging

### DIFF
--- a/apps/cvmfs_services/src/cvmfs_auth.erl
+++ b/apps/cvmfs_services/src/cvmfs_auth.erl
@@ -143,7 +143,6 @@ init({RepoList, Keys}) ->
     p_populate_keys(Keys),
     lager:info("Key list initialized."),
 
-    lager:info("Auth module initialized."),
     {ok, []}.
 
 %%--------------------------------------------------------------------
@@ -155,31 +154,24 @@ init({RepoList, Keys}) ->
 %%--------------------------------------------------------------------
 handle_call({auth_req, check_keyid_for_repo, {KeyId, Repo}}, _From, State) ->
     Reply = p_check_keyid_for_repo(KeyId, Repo),
-    lager:info("Request received: {check_keyid_for_repo, {~p, ~p}} -> Reply: ~p", [KeyId, Repo, Reply]),
     {reply, Reply, State};
 handle_call({auth_req, add_key, {KeyId, Secret}}, _From, State) ->
     Reply = p_add_key(KeyId, Secret),
-    lager:info("Request received: {add_key, {~p}} -> Reply: ~p", [KeyId, Reply]),
     {reply, Reply, State};
 handle_call({auth_req, remove_key, Key}, _From, State) ->
     Reply = p_remove_key(Key),
-    lager:info("Request received: {remove_key, ~p} -> Reply: ~p", [Key, Reply]),
     {reply, Reply, State};
 handle_call({auth_req, add_repo, {Repo, KeyIds}}, _From, State) ->
     Reply = p_add_repo(Repo, KeyIds),
-    lager:info("Request received: {add_repo, {~p, ~p}} -> Reply: ~p", [Repo, KeyIds, Reply]),
     {reply, Reply, State};
 handle_call({auth_req, remove_repo, Repo}, _From, State) ->
     Reply = p_remove_repo(Repo),
-    lager:info("Request received: {remove_repo, ~p} -> Reply: ~p", [Repo, Reply]),
     {reply, Reply, State};
 handle_call({auth_req, get_repos}, _From, State) ->
     Reply = p_get_repos(),
-    lager:info("Request received: {get_repos} -> Reply: ~p", [Reply]),
     {reply, Reply, State};
 handle_call({auth_req, check_hmac, {Message, KeyId, HMAC}}, _From, State) ->
     Reply = p_check_hmac(Message, KeyId, HMAC),
-    lager:info("Request received: {check_hmac, ~p, ~p, ~p} -> Reply: ~p", [Message, KeyId, HMAC, Reply]),
     {reply, Reply, State}.
 
 
@@ -309,9 +301,7 @@ p_check_hmac(Message, KeyId, HMAC) ->
     {atomic, Result} = mnesia:transaction(T),
     case Result of
         {ok, Secret} ->
-            ComputedHMAC = cvmfs_auth_util:compute_hmac(Secret, Message),
-            lager:info("HMAC: ~p Computed HMAC: ~p", [HMAC, ComputedHMAC]),
-            HMAC =:= ComputedHMAC;
+            HMAC =:= cvmfs_auth_util:compute_hmac(Secret, Message);
         _ ->
             false
     end.

--- a/apps/cvmfs_services/src/cvmfs_fe.erl
+++ b/apps/cvmfs_services/src/cvmfs_fe.erl
@@ -25,7 +25,7 @@ start_link() ->
     Dispatch = cowboy_router:compile([{'_', [
                                              {?API_ROOT, cvmfs_root_handler, []},
                                              {?API_ROOT ++ "/repos/[:id]", cvmfs_repos_handler, []},
-                                             {?API_ROOT ++ "/leases/[:token_id]", cvmfs_leases_handler, []},
+                                             {?API_ROOT ++ "/leases/[:token]", cvmfs_leases_handler, []},
                                              {?API_ROOT ++ "/payloads/[:id]", cvmfs_payloads_handler, []}
                                             ]}]),
     %% Start the HTTP listener process configured with the routing table

--- a/apps/cvmfs_services/src/cvmfs_fe_util.erl
+++ b/apps/cvmfs_services/src/cvmfs_fe_util.erl
@@ -10,10 +10,12 @@
 
 -compile([{parse_transform, lager_transform}]).
 
--export([read_body/1, tick/2, tock/3]).
+-export([read_body/1, tick/2, tock/4]).
+
 
 read_body(Req0) ->
     read_body_rec(Req0, <<"">>).
+
 
 read_body_rec(Req0, Acc) ->
     case cowboy_req:read_body(Req0) of
@@ -25,11 +27,14 @@ read_body_rec(Req0, Acc) ->
             read_body_rec(Req1, <<Data:DataSize/binary,Acc/binary>>)
     end.
 
+
 tick(Req, Unit) ->
     T = erlang:monotonic_time(Unit),
     URI = cowboy_req:uri(Req),
     {URI, T}.
 
-tock(URI, T0, Unit) ->
+
+tock(Uid, URI, T0, Unit) ->
     T1 = erlang:monotonic_time(Unit),
-    lager:info("HTTP request received: ~p ; time to process = ~p usec", [URI, T1 - T0]).
+    lager:info("HTTP request received; Uid: ~p;  URI: ~p; Time to process = ~p usec", [Uid, URI, T1 - T0]).
+

--- a/apps/cvmfs_services/src/cvmfs_fe_util.erl
+++ b/apps/cvmfs_services/src/cvmfs_fe_util.erl
@@ -10,7 +10,7 @@
 
 -compile([{parse_transform, lager_transform}]).
 
--export([read_body/1, tick/2, tock/4]).
+-export([read_body/1, tick/2, tock/5]).
 
 
 read_body(Req0) ->
@@ -34,7 +34,8 @@ tick(Req, Unit) ->
     {URI, T}.
 
 
-tock(Uid, URI, T0, Unit) ->
+tock(Uid, Method, URI, T0, Unit) ->
     T1 = erlang:monotonic_time(Unit),
-    lager:info("HTTP request received; Uid: ~p;  URI: ~p; Time to process = ~p usec", [Uid, URI, T1 - T0]).
+    lager:info("HTTP request received; Uid: ~p; Method: ~p; URI: ~p; Time to process = ~p usec",
+               [Uid, Method, URI, T1 - T0]).
 

--- a/apps/cvmfs_services/src/cvmfs_lease.erl
+++ b/apps/cvmfs_services/src/cvmfs_lease.erl
@@ -142,6 +142,8 @@ init(_) ->
                                ,{index, [public]}]),
     ok = mnesia:wait_for_tables([lease], 10000),
     lager:info("Lease table initialized"),
+
+    lager:info("Lease module initialized."),
     {ok, {}}.
 
 %%--------------------------------------------------------------------
@@ -153,28 +155,18 @@ init(_) ->
 %%--------------------------------------------------------------------
 handle_call({lease_req, new_lease, {User, Path, Public, Secret}}, _From, State) ->
     Reply = p_new_lease(User, Path, Public, Secret, State),
-    lager:info("Request received: {new_lease, ~p} -> Reply: ~p"
-              ,[{User, Path}, Reply]),
     {reply, Reply, State};
 handle_call({lease_req, end_lease, Public}, _From, State) ->
     Reply = p_end_lease(Public),
-    lager:info("Request received: {end_lease, ~p} -> Reply: ~p"
-              ,[Public, Reply]),
     {reply, Reply, State};
 handle_call({lease_req, check_lease, Public}, _From, State) ->
     Reply = p_check_lease(Public),
-    lager:info("Request received: {check_lease, ~p} -> Reply: ~p"
-              ,[Public, Reply]),
     {reply, Reply, State};
 handle_call({lease_req, get_leases}, _From, State) ->
     Reply = p_get_leases(),
-    lager:info("Request received: {get_leases} -> Reply: ~p"
-              ,[Reply]),
     {reply, Reply, State};
 handle_call({lease_req, clear_leases}, _From, State) ->
     Reply = p_clear_leases(),
-    lager:info("Request received: {clear_leases} -> Reply: ~p"
-              ,[Reply]),
     {reply, Reply, State};
 handle_call(_Request, _From, State) ->
     Reply = ok,

--- a/apps/cvmfs_services/src/cvmfs_leases_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_leases_handler.erl
@@ -136,7 +136,7 @@ init(Req0 = #{method := <<"DELETE">>}, State) ->
 %% Private functions
 
 p_check_hmac(JSONMessage, KeyId, ClientHMAC) ->
-    cvmfs_auth:check_hmac(JSONMessage, KeyId, ClientHMAC).
+    cvmfs_be:check_hmac(JSONMessage, KeyId, ClientHMAC).
 
 
 p_new_lease(KeyId, Path) ->

--- a/apps/cvmfs_services/src/cvmfs_leases_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_leases_handler.erl
@@ -30,7 +30,7 @@ init(Req0 = #{method := <<"GET">>}, State) ->
                            <<"">>,
                            Req0),
 
-    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, <<"GET">>, URI, T0, micro_seconds),
     {ok, Req1, State};
 %%--------------------------------------------------------------------
 %% @doc
@@ -76,7 +76,7 @@ init(Req0 = #{method := <<"POST">>}, State) ->
                             jsx:encode(Reply),
                             Req2),
 
-    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, <<"POST">>, URI, T0, micro_seconds),
     {ok, ReqF, State};
 %%--------------------------------------------------------------------
 %% @doc
@@ -132,7 +132,7 @@ init(Req0 = #{method := <<"DELETE">>}, State) ->
                                 {ok, Req1, State}
                         end,
 
-    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, <<"DELETE">>, URI, T0, micro_seconds),
     {ok, ReqF, State}.
 
 

--- a/apps/cvmfs_services/src/cvmfs_leases_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_leases_handler.erl
@@ -52,6 +52,7 @@ init(Req0 = #{method := <<"GET">>}, State) ->
 %%--------------------------------------------------------------------
 init(Req0 = #{method := <<"POST">>}, State) ->
     {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+    Uid = cvmfs_be:unique_id(),
 
     #{headers := #{<<"authorization">> := Auth}} = Req0,
     [KeyId, ClientHMAC] = binary:split(Auth, <<" ">>),
@@ -74,7 +75,7 @@ init(Req0 = #{method := <<"POST">>}, State) ->
                             jsx:encode(Reply),
                             Req2),
 
-    cvmfs_fe_util:tock(URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
     {ok, ReqF, State};
 %%--------------------------------------------------------------------
 %% @doc
@@ -96,6 +97,7 @@ init(Req0 = #{method := <<"POST">>}, State) ->
 %%--------------------------------------------------------------------
 init(Req0 = #{method := <<"DELETE">>}, State) ->
     {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+    Uid = cvmfs_be:unique_id(),
 
     #{headers := #{<<"authorization">> := Auth}} = Req0,
     [KeyId, ClientHMAC] = binary:split(Auth, <<" ">>),
@@ -129,7 +131,7 @@ init(Req0 = #{method := <<"DELETE">>}, State) ->
                                 {ok, Req1, State}
                         end,
 
-    cvmfs_fe_util:tock(URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
     {ok, ReqF, State}.
 
 

--- a/apps/cvmfs_services/src/cvmfs_leases_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_leases_handler.erl
@@ -99,7 +99,7 @@ init(Req0 = #{method := <<"DELETE">>}, State) ->
 
     #{headers := #{<<"authorization">> := Auth}} = Req0,
     [KeyId, ClientHMAC] = binary:split(Auth, <<" ">>),
-    {ok, ReqF, State} = case cowboy_req:binding(token_id, Req0) of
+    {ok, ReqF, State} = case cowboy_req:binding(token, Req0) of
                             undefined ->
                                 Reply = #{<<"status">> => <<"error">>,
                                           <<"reason">> => <<"Missing token. Call /api/v1/leases/<TOKEN>">>},

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -52,6 +52,7 @@ init(Req0 = #{method := <<"GET">>}, State) ->
 %%--------------------------------------------------------------------
 init(Req0 = #{method := <<"POST">>}, State) ->
     {_, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+    Uid = cvmfs_be:unique_id(),
 
     #{headers := #{<<"authorization">> := Auth, <<"message-size">> := MessageSizeBin}} = Req0,
     [KeyId, ClientHMAC] = binary:split(Auth, <<" ">>),
@@ -76,7 +77,7 @@ init(Req0 = #{method := <<"POST">>}, State) ->
                             jsx:encode(Reply),
                             Req2),
 
-    cvmfs_fe_util:tock(<<"payload_not_shown">>, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, Uid, T0, micro_seconds),
     {ok, ReqF, State}.
 
 

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -24,13 +24,14 @@
 %%--------------------------------------------------------------------
 init(Req0 = #{method := <<"GET">>}, State) ->
     {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+    Uid = cvmfs_be:unique_id(),
 
     Req1 = cowboy_req:reply(405,
                            #{<<"content-type">> => <<"application/plain-text">>},
                            <<"">>,
                            Req0),
 
-    cvmfs_fe_util:tock(URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
     {ok, Req1, State};
 %% @doc
 %% A "POST" request to /api/payloads, which can return either 200 OK
@@ -61,9 +62,9 @@ init(Req0 = #{method := <<"POST">>}, State) ->
     <<JSONMessage:MessageSize/binary,Payload/binary>> = Data,
     {Status, Reply, Req2} = case jsx:decode(JSONMessage, [return_maps]) of
                                 #{<<"session_token">> := Token} ->
-                                    Rep = case cvmfs_be:check_hmac(JSONMessage, KeyId, ClientHMAC) of
+                                    Rep = case cvmfs_be:check_hmac(Uid, JSONMessage, KeyId, ClientHMAC) of
                                               true ->
-                                                  p_submit_payload(Token, Payload);
+                                                  p_submit_payload(Uid, Token, Payload);
                                               false ->
                                                   #{<<"status">> => <<"error">>,
                                                     <<"reason">> => <<"invalid_hmac">>}
@@ -84,8 +85,8 @@ init(Req0 = #{method := <<"POST">>}, State) ->
 %% Private functions
 
 
-p_submit_payload(Token, Payload) ->
-    case cvmfs_be:submit_payload(Token, Payload) of
+p_submit_payload(Uid, Token, Payload) ->
+    case cvmfs_be:submit_payload(Uid, Token, Payload) of
         {ok, payload_added} ->
             #{<<"status">> => <<"ok">>};
         {error, Reason} ->

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -31,7 +31,7 @@ init(Req0 = #{method := <<"GET">>}, State) ->
                            <<"">>,
                            Req0),
 
-    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, <<"GET">>, URI, T0, micro_seconds),
     {ok, Req1, State};
 %% @doc
 %% A "POST" request to /api/payloads, which can return either 200 OK
@@ -52,7 +52,7 @@ init(Req0 = #{method := <<"GET">>}, State) ->
 %% @end
 %%--------------------------------------------------------------------
 init(Req0 = #{method := <<"POST">>}, State) ->
-    {_, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+    {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
     Uid = cvmfs_be:unique_id(),
 
     #{headers := #{<<"authorization">> := Auth, <<"message-size">> := MessageSizeBin}} = Req0,
@@ -78,7 +78,7 @@ init(Req0 = #{method := <<"POST">>}, State) ->
                             jsx:encode(Reply),
                             Req2),
 
-    cvmfs_fe_util:tock(Uid, Uid, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, <<"POST">>, URI, T0, micro_seconds),
     {ok, ReqF, State}.
 
 

--- a/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_payloads_handler.erl
@@ -60,7 +60,7 @@ init(Req0 = #{method := <<"POST">>}, State) ->
     <<JSONMessage:MessageSize/binary,Payload/binary>> = Data,
     {Status, Reply, Req2} = case jsx:decode(JSONMessage, [return_maps]) of
                                 #{<<"session_token">> := Token} ->
-                                    Rep = case cvmfs_auth:check_hmac(JSONMessage, KeyId, ClientHMAC) of
+                                    Rep = case cvmfs_be:check_hmac(JSONMessage, KeyId, ClientHMAC) of
                                               true ->
                                                   p_submit_payload(Token, Payload);
                                               false ->

--- a/apps/cvmfs_services/src/cvmfs_repos_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_repos_handler.erl
@@ -27,6 +27,6 @@ init(Req0, State) ->
                            jsx:encode(#{<<"repos">> => Repos}),
                            Req0),
 
-    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, <<"GET">>, URI, T0, micro_seconds),
     {ok, Req, State}.
 

--- a/apps/cvmfs_services/src/cvmfs_repos_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_repos_handler.erl
@@ -19,6 +19,7 @@
 %%--------------------------------------------------------------------
 init(Req0, State) ->
     {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+    Uid = cvmfs_be:unique_id(),
 
     Repos = cvmfs_be:get_repos(),
     Req = cowboy_req:reply(200,
@@ -26,6 +27,6 @@ init(Req0, State) ->
                            jsx:encode(#{<<"repos">> => Repos}),
                            Req0),
 
-    cvmfs_fe_util:tock(URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
     {ok, Req, State}.
 

--- a/apps/cvmfs_services/src/cvmfs_repos_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_repos_handler.erl
@@ -20,7 +20,7 @@
 init(Req0, State) ->
     {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
 
-    Repos = cvmfs_auth:get_repos(),
+    Repos = cvmfs_be:get_repos(),
     Req = cowboy_req:reply(200,
                            #{<<"content-type">> => <<"application/json">>},
                            jsx:encode(#{<<"repos">> => Repos}),

--- a/apps/cvmfs_services/src/cvmfs_repos_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_repos_handler.erl
@@ -21,7 +21,7 @@ init(Req0, State) ->
     {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
     Uid = cvmfs_be:unique_id(),
 
-    Repos = cvmfs_be:get_repos(),
+    Repos = cvmfs_be:get_repos(Uid),
     Req = cowboy_req:reply(200,
                            #{<<"content-type">> => <<"application/json">>},
                            jsx:encode(#{<<"repos">> => Repos}),

--- a/apps/cvmfs_services/src/cvmfs_root_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_root_handler.erl
@@ -30,6 +30,6 @@ init(Req0, State) ->
                            jsx:encode(API),
                            Req0),
 
-    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, <<"GET">>, URI, T0, micro_seconds),
     {ok, Req, State}.
 

--- a/apps/cvmfs_services/src/cvmfs_root_handler.erl
+++ b/apps/cvmfs_services/src/cvmfs_root_handler.erl
@@ -20,6 +20,7 @@
 %%--------------------------------------------------------------------
 init(Req0, State) ->
     {URI, T0} = cvmfs_fe_util:tick(Req0, micro_seconds),
+    Uid = cvmfs_be:unique_id(),
 
     Banner = <<"You are in an open field on the west side of a white house with a boarded front door.">>,
     API = #{<<"banner">> => Banner,
@@ -29,6 +30,6 @@ init(Req0, State) ->
                            jsx:encode(API),
                            Req0),
 
-    cvmfs_fe_util:tock(URI, T0, micro_seconds),
+    cvmfs_fe_util:tock(Uid, URI, T0, micro_seconds),
     {ok, Req, State}.
 

--- a/apps/cvmfs_services/test/cvmfs_be_SUITE.erl
+++ b/apps/cvmfs_services/test/cvmfs_be_SUITE.erl
@@ -33,6 +33,9 @@
         ,submission_with_expired_token_fails/1]).
 
 
+-define(TEST_UID, <<"TEST_UID">>).
+
+
 %% Tests description
 
 all() ->
@@ -95,39 +98,39 @@ end_per_testcase(_TestCase, _Config) ->
 % New lease
 % Valid key and valid path should be accepted
 valid_key_valid_path(_Config) ->
-    {ok, Token} = cvmfs_be:new_lease(<<"key1">>, <<"repo1.domain1.org">>),
-    ok = cvmfs_be:end_lease(Token).
+    {ok, Token} = cvmfs_be:new_lease(?TEST_UID, <<"key1">>, <<"repo1.domain1.org">>),
+    ok = cvmfs_be:end_lease(?TEST_UID, Token).
 % Valid key and busy path should be rejected with remaining time
 valid_key_busy_path(_Config) ->
-    {ok, Token} = cvmfs_be:new_lease(<<"key1">>, <<"repo1.domain1.org">>),
-    {path_busy, _} = cvmfs_be:new_lease(<<"key1">>, <<"repo1.domain1.org">>),
-    ok = cvmfs_be:end_lease(Token).
+    {ok, Token} = cvmfs_be:new_lease(?TEST_UID, <<"key1">>, <<"repo1.domain1.org">>),
+    {path_busy, _} = cvmfs_be:new_lease(?TEST_UID, <<"key1">>, <<"repo1.domain1.org">>),
+    ok = cvmfs_be:end_lease(?TEST_UID, Token).
 % Invalid key and valid path should be rejected
 invalid_key_valid_path(_Config) ->
-    {error, invalid_key} = cvmfs_be:new_lease(<<"key2">>, <<"repo1.domain1.org">>).
+    {error, invalid_key} = cvmfs_be:new_lease(?TEST_UID, <<"key2">>, <<"repo1.domain1.org">>).
 % Valid key and invalid path should be rejected
 valid_key_invalid_path(_Config) ->
-    {error, invalid_path} = cvmfs_be:new_lease(<<"key1">>, <<"repo1.domain1.com">>).
+    {error, invalid_path} = cvmfs_be:new_lease(?TEST_UID, <<"key1">>, <<"repo1.domain1.com">>).
 % Invalid key and invalid path should be rejected with {error, invalid_key}
 invalid_key_invalid_path(_Config) ->
-    {error, invalid_path} = cvmfs_be:new_lease(<<"key2">>, <<"repo1.domain1.com">>).
+    {error, invalid_path} = cvmfs_be:new_lease(?TEST_UID, <<"key2">>, <<"repo1.domain1.com">>).
 
 % End lease
 % End valid lease
 end_valid_lease(_Config) ->
-    {ok, Token} = cvmfs_be:new_lease(<<"key1">>, <<"repo1.domain1.org">>),
-    ok = cvmfs_be:end_lease(Token).
+    {ok, Token} = cvmfs_be:new_lease(?TEST_UID, <<"key1">>, <<"repo1.domain1.org">>),
+    ok = cvmfs_be:end_lease(?TEST_UID, Token).
 
 % End invalid lease
 end_invalid_lease(_Config) ->
-    {ok, Token} = cvmfs_be:new_lease(<<"key1">>, <<"repo1.domain1.org">>),
-    ok = cvmfs_be:end_lease(Token),
-    ok = cvmfs_be:end_lease(Token).
+    {ok, Token} = cvmfs_be:new_lease(?TEST_UID, <<"key1">>, <<"repo1.domain1.org">>),
+    ok = cvmfs_be:end_lease(?TEST_UID, Token),
+    ok = cvmfs_be:end_lease(?TEST_UID, Token).
 
 % End lease invalid macaroon
 end_lease_invalid_macaroon(_Config) ->
     Token = <<"fake_token">>,
-    {error, invalid_macaroon} = cvmfs_be:end_lease(Token).
+    {error, invalid_macaroon} = cvmfs_be:end_lease(?TEST_UID, Token).
 
 % Submit payload
 % Normal lease check
@@ -135,28 +138,28 @@ lease_success(_Config) ->
     % Start with a valid key and path and receive a valid lease token
     {Key, Path} = {<<"key1">>, <<"repo1.domain1.org">>},
     Payload = <<"placeholder_for_a_real_payload">>,
-    {ok, Token} = cvmfs_be:new_lease(Key, Path),
+    {ok, Token} = cvmfs_be:new_lease(?TEST_UID, Key, Path),
     % Followup with a payload submission
-    {ok, payload_added} = cvmfs_be:submit_payload(Token, Payload),
+    {ok, payload_added} = cvmfs_be:submit_payload(?TEST_UID, Token, Payload),
     % Submit final payload and end the lease
-    {ok, payload_added} = cvmfs_be:submit_payload(Token, Payload),
-    ok = cvmfs_be:end_lease(Token),
+    {ok, payload_added} = cvmfs_be:submit_payload(?TEST_UID, Token, Payload),
+    ok = cvmfs_be:end_lease(?TEST_UID, Token),
     % After the lease has been closed, the token should be rejected
-    {error, invalid_lease} = cvmfs_be:submit_payload(Token, Payload).
+    {error, invalid_lease} = cvmfs_be:submit_payload(?TEST_UID, Token, Payload).
 
 % Attempt to submit a payload without first obtaining a token
 submission_with_invalid_token_fails(_Config) ->
     Token = <<"invalid_token">>,
     Payload = <<"placeholder">>,
-    {error, invalid_macaroon} = cvmfs_be:submit_payload(Token, Payload).
+    {error, invalid_macaroon} = cvmfs_be:submit_payload(?TEST_UID, Token, Payload).
 
 % Start a valid lease, make submission after the token has expired
 submission_with_expired_token_fails(Config) ->
     {Key, Path} = {<<"key1">>, <<"repo1.domain1.org">>},
     Payload = <<"placeholder">>,
-    {ok, Token} = cvmfs_be:new_lease(Key, Path),
+    {ok, Token} = cvmfs_be:new_lease(?TEST_UID, Key, Path),
     ct:sleep(?config(max_lease_time, Config)),
-    {error, lease_expired} = cvmfs_be:submit_payload(Token, Payload).
+    {error, lease_expired} = cvmfs_be:submit_payload(?TEST_UID, Token, Payload).
 
 
 %% Properties

--- a/rebar.config
+++ b/rebar.config
@@ -3,8 +3,8 @@
         {lager, "3.2.1"},
         {macaroons, "1.0.2", {git, "https://github.com/kzemek/macaroons.git", {tag, "1.0.2"}}},
         {cowboy, {git, "https://github.com/ninenines/cowboy.git", {branch, "master"}}},
-        {jsx, "2.8.0"}
-       ]}.
+        {jsx, "2.8.0"},
+        {uuid, "1.6.0", {pkg, uuid_erl}}]}.
 
 {relx, [{release, {cvmfs_services, "0.1.0"}
         ,[cvmfs_services,

--- a/rebar.lock
+++ b/rebar.lock
@@ -22,13 +22,17 @@
   {git,"https://github.com/kzemek/macaroons.git",
        {ref,"9d2fef9f37e6b96a68aaaa81c0e5272d61a8b3b0"}},
   0},
+ {<<"quickrand">>,{pkg,<<"quickrand">>,<<"1.6.0">>},1},
  {<<"ranch">>,
   {git,"https://github.com/ninenines/ranch",
        {ref,"a5d2efcde9a34ad38ab89a26d98ea5335e88625a"}},
-  1}]}.
+  1},
+ {<<"uuid">>,{pkg,<<"uuid_erl">>,<<"1.6.0">>},0}]}.
 [
 {pkg_hash,[
  {<<"goldrush">>, <<"2024BA375CEEA47E27EA70E14D2C483B2D8610101B4E852EF7F89163CDB6E649">>},
  {<<"jsx">>, <<"749BEC6D205C694AE1786D62CEA6CC45A390437E24835FD16D12D74F07097727">>},
- {<<"lager">>, <<"EEF4E18B39E4195D37606D9088EA05BF1B745986CF8EC84F01D332456FE88D17">>}]}
+ {<<"lager">>, <<"EEF4E18B39E4195D37606D9088EA05BF1B745986CF8EC84F01D332456FE88D17">>},
+ {<<"quickrand">>, <<"33A277A639C442D77AB5C1EEA4641A49E3F034FD13658BB57E192A6E083FE77D">>},
+ {<<"uuid">>, <<"1BA81515EEB37EEB7F1563B658E30CDF18BCAF1FD6A390BBF3838461753E69D8">>}]}
 ].


### PR DESCRIPTION
* Tag all frontend API calls with a unique id (UUIDv1) which is forwarded with any backend calls and included in all logging statements.
* Make logging less noisy: only log frontend (HTTP) API calls and calls to backend functions.
* The frontend only interacts directly with the backend. The backend is the only module which can call other modules, such as `cvmfs_auth` and `cvmfs_lease`.