### PR TITLE
Integrate with CI

### DIFF
--- a/ci/make_tarball.sh
+++ b/ci/make_tarball.sh
@@ -14,6 +14,8 @@ CVMFS_BUILD_LOCATION="$1"
 shift 1
 
 export DEBUG=1
+echo "Rebar cache dir: $REBAR_CACHE_DIR"
+
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."
 cd "$CVMFS_BUILD_LOCATION"

--- a/ci/make_tarball.sh
+++ b/ci/make_tarball.sh
@@ -13,6 +13,9 @@ fi
 CVMFS_BUILD_LOCATION="$1"
 shift 1
 
+export REBAR_CACHE_DIR=$CVMFS_BUILD_LOCATION/../
+mkdir -p $REBAR_CACHE_DIR
+
 export DEBUG=1
 echo "Rebar cache dir: $REBAR_CACHE_DIR"
 

--- a/ci/make_tarball.sh
+++ b/ci/make_tarball.sh
@@ -13,8 +13,7 @@ fi
 CVMFS_BUILD_LOCATION="$1"
 shift 1
 
-echo "$(env)"
-
+export DEBUG=1
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."
 cd "$CVMFS_BUILD_LOCATION"

--- a/ci/make_tarball.sh
+++ b/ci/make_tarball.sh
@@ -13,8 +13,6 @@ fi
 CVMFS_BUILD_LOCATION="$1"
 shift 1
 
-export REBAR_CACHE_DIR=$WORKSPACE
-
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."
 cd "$CVMFS_BUILD_LOCATION"

--- a/ci/make_tarball.sh
+++ b/ci/make_tarball.sh
@@ -16,11 +16,13 @@ shift 1
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."
 cd "$CVMFS_BUILD_LOCATION"
+set +e
 rebar3 as prod compile
 cd _build/prod/lib/syslog
 ./rebar compile
 cd -
 rebar3 as prod release,tar
+set -e
 REPO_SERVICES_VERSION=$(grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" apps/cvmfs_services/src/cvmfs_services.app.src)
 mkdir -p $CVMFS_BUILD_LOCATION/tarballs
 cp -v _build/prod/rel/cvmfs_services/cvmfs_services-$REPO_SERVICES_VERSION.tar.gz \

--- a/ci/make_tarball.sh
+++ b/ci/make_tarball.sh
@@ -13,6 +13,8 @@ fi
 CVMFS_BUILD_LOCATION="$1"
 shift 1
 
+echo "$(env)"
+
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."
 cd "$CVMFS_BUILD_LOCATION"

--- a/ci/make_tarball.sh
+++ b/ci/make_tarball.sh
@@ -1,7 +1,27 @@
 #!/bin/sh
 
+set -e
+
+SCRIPT_LOCATION=$(cd "$(dirname "$0")"; pwd)
+
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <CernVM-FS source directory (the same as the build directory)>"
+  echo "This script builds packages for the current platform."
+  exit 1
+fi
+
+CVMFS_BUILD_LOCATION="$1"
+shift 1
+
+# run the build script
+echo "switching to $CVMFS_BUILD_LOCATION..."
+cd "$CVMFS_BUILD_LOCATION"
 rebar3 as prod compile
 cd _build/prod/lib/syslog
 ./rebar compile
 cd -
 rebar3 as prod release,tar
+REPO_SERVICES_VERSION=$(grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" apps/cvmfs_services/src/cvmfs_services.app.src)
+mkdir -p $CVMFS_BUILD_LOCATION/tarballs
+cp -v _build/prod/rel/cvmfs_services/cvmfs_services-$REPO_SERVICES_VERSION.tar.gz \
+   $CVMFS_BUILD_LOCATION/tarballs/cvmfs_services-$REPO_SERVICES_VERSION-$CVMFS_BUILD_PLATFORM-x86_64.tar.gz

--- a/ci/make_tarball.sh
+++ b/ci/make_tarball.sh
@@ -16,9 +16,6 @@ shift 1
 export REBAR_CACHE_DIR=$CVMFS_BUILD_LOCATION/../
 mkdir -p $REBAR_CACHE_DIR
 
-export DEBUG=1
-echo "Rebar cache dir: $REBAR_CACHE_DIR"
-
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."
 cd "$CVMFS_BUILD_LOCATION"

--- a/ci/make_tarball.sh
+++ b/ci/make_tarball.sh
@@ -13,16 +13,16 @@ fi
 CVMFS_BUILD_LOCATION="$1"
 shift 1
 
+export REBAR_CACHE_DIR=$WORKSPACE
+
 # run the build script
 echo "switching to $CVMFS_BUILD_LOCATION..."
 cd "$CVMFS_BUILD_LOCATION"
-set +e
 rebar3 as prod compile
 cd _build/prod/lib/syslog
 ./rebar compile
 cd -
 rebar3 as prod release,tar
-set -e
 REPO_SERVICES_VERSION=$(grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" apps/cvmfs_services/src/cvmfs_services.app.src)
 mkdir -p $CVMFS_BUILD_LOCATION/tarballs
 cp -v _build/prod/rel/cvmfs_services/cvmfs_services-$REPO_SERVICES_VERSION.tar.gz \

--- a/rebar.config
+++ b/rebar.config
@@ -1,11 +1,11 @@
 {erl_opts, [debug_info]}.
 {deps, [
         {lager, "3.2.1"},
-        {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.0.0-pre.7"}}},
+        {cowboy, {git, "https://github.com/ninenines/cowboy.git", {tag, "2.0.0-pre.10"}}},
         {jsx, "2.8.0"},
         {uuid, "1.6.0", {pkg, uuid_erl}},
         {poolboy, "1.5.1"},
-        {lager_syslog, {git, "https://github.com/basho/lager_syslog.git", {tag, "3.0.3"}}}
+        {lager_syslog, {git, "https://github.com/cvmfs/lager_syslog.git", {tag, "3.0.3"}}}
        ]}.
 {relx, [{release, {cvmfs_services, "0.1.8"}
         ,[cvmfs_services,


### PR DESCRIPTION
Update the `ci/make_tarball.sh` script to be usable inside the CernVM-FS CI system.